### PR TITLE
Dynamic locales to cache on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,18 @@ The language exceptions are:
 ## Configuration
 
 If you want to run your own bot instance,
-the telegram-bot-framework requires a few configuration values
-that must be set before running it (the auth token and admin user).
+the telegram-bot-framework requires a few configuration options
+that must be set before running it (like the auth token and admin user).
 
 Please, refer to the [telegram-bot-framework configuration section](https://github.com/alvarogzp/telegram-bot-framework#configuration)
 to set them.
+
+There are also configuration options specific to this bot.
+They are optional and if not specified their default values are used.
+They must be defined along with telegram-bot-framework configuration options (ie. in the same directory).
+The recognised options are:
+ - `enable_countries`, which, if defined and not empty, will make the bot return a 'country' as the first result with all country time zones when a country code is specified. By default, it is disabled.
+ - `locales_to_cache_on_startup`, that can have a space-separated or newline-separated list of locale codes to be cached on startup. By default, `en_US` and `es_ES` locales are cached.
 
 Once configured, you can run the `main.py` file directly, or the
 `run.sh` script that will set-up a virtual environment and install

--- a/clock/bot/inline/query/action.py
+++ b/clock/bot/inline/query/action.py
@@ -23,7 +23,8 @@ class InlineQueryClockAction(Action):
     def post_setup(self):
         self.zone_finder = ZoneFinderApi(bool(self.config.enable_countries))
         self.logger = LogApi.get(self.cache.logger)
-        self.locale_cache = LocaleCache(self.zone_finder.cache(), self.scheduler, self.logger)
+        initial_locales_to_cache = self.config.locales_to_cache_on_startup
+        self.locale_cache = LocaleCache(self.zone_finder.cache(), self.scheduler, self.logger, initial_locales_to_cache)
         # for others to use
         self.cache.zone_finder = self.zone_finder
         self.cache.locale_cache = self.locale_cache

--- a/clock/bot/locale_cache.py
+++ b/clock/bot/locale_cache.py
@@ -21,10 +21,10 @@ class LocaleCache:
         # this is a background cache, quickly processing queries is more important
         self.worker = scheduler.new_worker_pool("locale_cache", min_workers=0, max_workers=1, max_seconds_idle=60)
         self.log_api = log_api
-        self._cache_initial_locales(self._get_initial_locales(initial_locales_to_cache))
+        self._cache_initial_locales(self._parse_initial_locales(initial_locales_to_cache))
 
     @staticmethod
-    def _get_initial_locales(initial_locales_to_cache: str):
+    def _parse_initial_locales(initial_locales_to_cache: str):
         if initial_locales_to_cache is None:
             initial_locales_to_cache = DEFAULT_INITIAL_LOCALES_TO_CACHE
         for line in initial_locales_to_cache.splitlines():

--- a/clock/bot/locale_cache.py
+++ b/clock/bot/locale_cache.py
@@ -7,23 +7,35 @@ from clock.finder.api import ZoneFinderLocaleCache
 from clock.log.api import LogApi
 
 
-LOCALES_TO_CACHE_ON_STARTUP = [
-    Locale.parse("en_US"),
-    Locale.parse("es_ES")
-]
+DEFAULT_INITIAL_LOCALES_TO_CACHE = """
+en_US
+es_ES
+"""
 
 
 class LocaleCache:
-    def __init__(self, zone_finder_locale_cache: ZoneFinderLocaleCache, scheduler: SchedulerApi, log_api: LogApi):
+    def __init__(self, zone_finder_locale_cache: ZoneFinderLocaleCache, scheduler: SchedulerApi, log_api: LogApi,
+                 initial_locales_to_cache: str):
         self.locale_cache = zone_finder_locale_cache
         # using only one background thread to avoid consuming too many resources for locale caching
         # this is a background cache, quickly processing queries is more important
         self.worker = scheduler.new_worker_pool("locale_cache", min_workers=0, max_workers=1, max_seconds_idle=60)
         self.log_api = log_api
-        self._cache_initial_locales()
+        self._cache_initial_locales(self._get_initial_locales(initial_locales_to_cache))
 
-    def _cache_initial_locales(self):
-        for locale in LOCALES_TO_CACHE_ON_STARTUP:
+    @staticmethod
+    def _get_initial_locales(initial_locales_to_cache: str):
+        if initial_locales_to_cache is None:
+            initial_locales_to_cache = DEFAULT_INITIAL_LOCALES_TO_CACHE
+        for line in initial_locales_to_cache.splitlines():
+            for locale_code in line.split():
+                if locale_code.startswith("#"):
+                    # a comment was found, ignore until the next line
+                    break
+                yield Locale.parse(locale_code)
+
+    def _cache_initial_locales(self, initial_locales_to_cache: iter):
+        for locale in initial_locales_to_cache:
             self.cache(locale)
 
     def cache(self, locale: Locale):


### PR DESCRIPTION
- allow to specify the locales to cache on startup as a config option (`locales_to_cache_on_startup`)
  - as a list of locale codes separated by spaces or newlines
  - can have empty lines and comments
- document config options specific to clock-bot in README