### PR TITLE
Better locale handling

### DIFF
--- a/clock/bot/locale_cache.py
+++ b/clock/bot/locale_cache.py
@@ -4,12 +4,13 @@ from bot.multithreading.work import Work
 
 from clock.domain.time import TimePoint
 from clock.finder.api import ZoneFinderLocaleCache
+from clock.locale.getter import LocaleGetter
 from clock.log.api import LogApi
 
 
 DEFAULT_INITIAL_LOCALES_TO_CACHE = """
-en_US
-es_ES
+en-US
+es-ES
 """
 
 
@@ -28,11 +29,11 @@ class LocaleCache:
         if initial_locales_to_cache is None:
             initial_locales_to_cache = DEFAULT_INITIAL_LOCALES_TO_CACHE
         for line in initial_locales_to_cache.splitlines():
-            for locale_code in line.split():
-                if locale_code.startswith("#"):
+            for language_code in line.split():
+                if language_code.startswith("#"):
                     # a comment was found, ignore until the next line
                     break
-                yield Locale.parse(locale_code)
+                yield LocaleGetter.from_language_code(language_code)
 
     def _cache_initial_locales(self, initial_locales_to_cache: iter):
         for locale in initial_locales_to_cache:

--- a/clock/locale/getter.py
+++ b/clock/locale/getter.py
@@ -1,10 +1,7 @@
-from babel import Locale
 from bot.api.domain import ApiObject
 
+from clock.locale.parser import LocaleParser
 from clock.util.cache import Cache
-
-
-DEFAULT_LOCALE = Locale.parse("en_US")
 
 
 class LocaleGetter:
@@ -20,17 +17,11 @@ class LocaleGetter:
         self.cache = Cache()
 
     def get(self, language_code: str):
-        self.cache.get_or_generate(language_code, lambda: self._parse_locale(language_code))
+        return self.cache.get_or_generate(language_code, lambda: self._parse_locale(language_code))
 
     @staticmethod
     def _parse_locale(language_code: str):
-        try:
-            locale = Locale.parse(language_code, sep="-")
-        except Exception:
-            locale = None
-        if locale is None:
-            locale = DEFAULT_LOCALE
-        return locale
+        return LocaleParser.parse(language_code)
 
     @classmethod
     def from_language_code(cls, language_code: str):

--- a/clock/locale/getter.py
+++ b/clock/locale/getter.py
@@ -1,18 +1,42 @@
 from babel import Locale
 from bot.api.domain import ApiObject
 
+from clock.util.cache import Cache
+
 
 DEFAULT_LOCALE = Locale.parse("en_US")
 
 
 class LocaleGetter:
+    instance = None
+
+    @classmethod
+    def getter(cls):
+        if cls.instance is None:
+            cls.instance = LocaleGetter()
+        return cls.instance
+
+    def __init__(self):
+        self.cache = Cache()
+
+    def get(self, language_code: str):
+        self.cache.get_or_generate(language_code, lambda: self._parse_locale(language_code))
+
     @staticmethod
-    def from_user(user: ApiObject):
-        user_locale_code = user.language_code
+    def _parse_locale(language_code: str):
         try:
-            locale = Locale.parse(user_locale_code, sep="-")
+            locale = Locale.parse(language_code, sep="-")
         except Exception:
             locale = None
         if locale is None:
             locale = DEFAULT_LOCALE
         return locale
+
+    @classmethod
+    def from_language_code(cls, language_code: str):
+        return cls.getter().get(language_code)
+
+    @classmethod
+    def from_user(cls, user: ApiObject):
+        user_language_code = user.language_code
+        return cls.from_language_code(user_language_code)

--- a/clock/locale/parser.py
+++ b/clock/locale/parser.py
@@ -40,6 +40,8 @@ class LocaleParser:
             pass
         else:
             # return the language only (eg. "en")
-            yield language
+            if language:
+                yield language
             # return a special language code that will try to get the most common language for the territory
-            yield "und_" + territory
+            if territory:
+                yield "und_" + territory

--- a/clock/locale/parser.py
+++ b/clock/locale/parser.py
@@ -1,0 +1,45 @@
+import babel
+from babel import Locale
+
+
+DEFAULT_LOCALE = Locale.parse("en_US")
+
+
+class LocaleParser:
+    @classmethod
+    def parse(cls, language_code: str):
+        for language_code in cls._get_language_codes(language_code):
+            locale = cls._try_parse(language_code)
+            if locale is not None:
+                return locale
+        return DEFAULT_LOCALE
+
+    @staticmethod
+    def _try_parse(language_code: str):
+        """
+        Try to parse the language code, returning None on failure.
+        """
+        try:
+            return Locale.parse(language_code, sep="-")
+        except Exception:
+            pass
+
+    @staticmethod
+    def _get_language_codes(language_code: str):
+        """
+        Return all acceptable language codes for a given language code, in order of priority.
+        For example, for "en_US", it would return "en_US", "en", "und_US".
+        """
+        # first of all, return the language code as is
+        yield language_code
+        # if that does not produce a valid locale, split the language code in its individual parts
+        try:
+            language, territory, script, variant = babel.parse_locale(language_code, sep="-")
+        except Exception:
+            # the language code is not valid, we cannot give more codes for it
+            pass
+        else:
+            # return the language only (eg. "en")
+            yield language
+            # return a special language code that will try to get the most common language for the territory
+            yield "und_" + territory

--- a/clock/locale/parser.py
+++ b/clock/locale/parser.py
@@ -28,7 +28,7 @@ class LocaleParser:
     def _get_language_codes(language_code: str):
         """
         Return all acceptable language codes for a given language code, in order of priority.
-        For example, for "en_US", it would return "en_US", "en", "und_US".
+        For example, for "en-US", it would return "en-US", "en", "und-US".
         """
         # first of all, return the language code as is
         yield language_code
@@ -44,4 +44,4 @@ class LocaleParser:
                 yield language
             # return a special language code that will try to get the most common language for the territory
             if territory:
-                yield "und_" + territory
+                yield "und-" + territory


### PR DESCRIPTION
- cache parsed locale objects, as they are slow when locales are not found
- new LocaleParser with various parsing strategies when the full locale is not found
  - currently: try only the language, try the default language for the territory, and use the default locale if everything else fails
- use LocaleGetter in /cache and CacheLocale, so now their locales must be specified separated with `-`