### PR TITLE
Allow to receive results from storage calls

### DIFF
--- a/clock/bot/inline/chosen_result.py
+++ b/clock/bot/inline/chosen_result.py
@@ -15,12 +15,13 @@ class ChosenInlineResultClockAction(Action):
         query = chosen_result.query
         choosing_time = self.__get_choosing_time(timestamp)
 
+        # async operations:
+
         self.scheduler.io(Work(
             lambda: StorageApi.get().save_chosen_result(user, timestamp, chosen_zone_name, query, choosing_time),
             "storage:save_chosen_result"
         ))
 
-        # event.logger is async
         LogApi.get(event.logger).log_chosen_result(user, timestamp, chosen_zone_name, query, choosing_time)
 
     @staticmethod

--- a/clock/bot/inline/chosen_result.py
+++ b/clock/bot/inline/chosen_result.py
@@ -12,9 +12,11 @@ class ChosenInlineResultClockAction(Action):
         super().__init__()
         # initialized in post_setup
         self.logger = None
+        self.storage = None
 
     def post_setup(self):
         self.logger = self.cache.log_api
+        self.storage = self.cache.storage
 
     def process(self, event):
         chosen_result = event.chosen_result
@@ -25,10 +27,7 @@ class ChosenInlineResultClockAction(Action):
 
         # async operations:
 
-        self.scheduler.io(Work(
-            lambda: StorageApi.get().save_chosen_result(user, timestamp, chosen_zone_name, query, choosing_time),
-            "storage:save_chosen_result"
-        ))
+        self.storage.save_chosen_result(user, timestamp, chosen_zone_name, query, choosing_time),
 
         self.logger.log_chosen_result(user, timestamp, chosen_zone_name, query, choosing_time)
 

--- a/clock/bot/inline/chosen_result.py
+++ b/clock/bot/inline/chosen_result.py
@@ -8,6 +8,14 @@ from clock.storage.api import StorageApi
 
 
 class ChosenInlineResultClockAction(Action):
+    def __init__(self):
+        super().__init__()
+        # initialized in post_setup
+        self.logger = None
+
+    def post_setup(self):
+        self.logger = self.cache.log_api
+
     def process(self, event):
         chosen_result = event.chosen_result
         user = chosen_result.from_
@@ -22,7 +30,7 @@ class ChosenInlineResultClockAction(Action):
             "storage:save_chosen_result"
         ))
 
-        LogApi.get(event.logger).log_chosen_result(user, timestamp, chosen_zone_name, query, choosing_time)
+        self.logger.log_chosen_result(user, timestamp, chosen_zone_name, query, choosing_time)
 
     @staticmethod
     def __get_timestamp_and_chosen_zone_name_from_result_id(result_id):

--- a/clock/bot/inline/query/action.py
+++ b/clock/bot/inline/query/action.py
@@ -28,6 +28,7 @@ class InlineQueryClockAction(Action):
         self.locale_cache = LocaleCache(self.zone_finder.cache(), self.scheduler, self.logger, initial_locales_to_cache)
         # for others to use
         self.cache.zone_finder = self.zone_finder
+        self.cache.log_api = self.logger
         self.cache.locale_cache = self.locale_cache
 
     def process(self, event):

--- a/clock/bot/inline/query/action.py
+++ b/clock/bot/inline/query/action.py
@@ -16,9 +16,10 @@ MAX_RESULTS_PER_QUERY = 25
 class InlineQueryClockAction(Action):
     def __init__(self):
         super().__init__()
-        self.zone_finder = None  # initialized in post_setup when we have access to config
-        self.logger = None  # initialized in post_setup
-        self.locale_cache = None  # initialized in post_setup
+        # values initialized in post_setup as they need access to values not yet available
+        self.zone_finder = None
+        self.logger = None
+        self.locale_cache = None
 
     def post_setup(self):
         self.zone_finder = ZoneFinderApi(bool(self.config.enable_countries))
@@ -48,13 +49,14 @@ class InlineQueryClockAction(Action):
         result = AnswerInlineQueryResultGenerator.generate(query, results, next_offset)
         self.api.async.answerInlineQuery(**result)
 
+        # async operations:
+
         self.locale_cache.cache(locale)
 
         self.__storage_schedule_save_query(
             lambda: StorageApi.get().save_query(query, current_time, locale, zones, results, processing_time)
         )
 
-        # event.logger is async
         self.logger.log_query(query, current_time, locale, zones, results, processing_time)
 
     @staticmethod

--- a/clock/bot/inline/query/action.py
+++ b/clock/bot/inline/query/action.py
@@ -32,6 +32,7 @@ class InlineQueryClockAction(Action):
         self.cache.zone_finder = self.zone_finder
         self.cache.log_api = self.logger
         self.cache.locale_cache = self.locale_cache
+        self.cache.storage = self.storage
 
     def process(self, event):
         current_time = TimePoint.current()

--- a/clock/bot/manager.py
+++ b/clock/bot/manager.py
@@ -31,7 +31,7 @@ class BotManager:
     def setup_actions(self):
         self.bot.set_action(
             ActionGroup(
-                LoggerAction().then(
+                LoggerAction(reuse_max_length=2000, reuse_max_time=1, reuse_max_number=10).then(
 
                     InlineQueryAction().then(
                         AsynchronousAction(

--- a/clock/storage/api.py
+++ b/clock/storage/api.py
@@ -2,6 +2,7 @@ from babel import Locale
 from bot.api.domain import ApiObject
 
 from clock.domain.time import TimePoint
+from clock.storage.async.scheduler import StorageScheduler
 from clock.storage.data_source.data_source import StorageDataSource
 from clock.storage.data_source.data_sources.sqlite import SqliteStorageDataSource
 
@@ -16,11 +17,24 @@ class StorageApi:
             cls._instance = StorageApi(SqliteStorageDataSource())
         return cls._instance
 
-    def __init__(self, data_source: StorageDataSource):
+    def __init__(self, data_source: StorageDataSource, scheduler: StorageScheduler):
         self.data_source = data_source
+        self.scheduler = scheduler
 
     def save_query(self, query: ApiObject, time_point: TimePoint, locale: Locale, results_found: list,
                    results_sent: list, processing_seconds: float):
+        self.scheduler.schedule_no_result(
+            lambda: self._save_query(query, time_point, locale, results_found, results_sent, processing_seconds)
+        )
+
+    def save_chosen_result(self, user: ApiObject, timestamp: str, chosen_zone_name: str, query: str,
+                           choosing_seconds: float):
+        self.scheduler.schedule_no_result(
+            lambda: self._save_chosen_result(user, timestamp, chosen_zone_name, query, choosing_seconds)
+        )
+
+    def _save_query(self, query: ApiObject, time_point: TimePoint, locale: Locale, results_found: list,
+                    results_sent: list, processing_seconds: float):
         self._save_user(query.from_)
         self.data_source.save_query(query.from_.id, time_point.id(), query.query, query.offset, str(locale),
                                     len(results_found), len(results_sent), processing_seconds)
@@ -29,8 +43,8 @@ class StorageApi:
     def _save_user(self, user: ApiObject):
         self.data_source.save_user(user.id, user.first_name, user.last_name, user.username, user.language_code)
 
-    def save_chosen_result(self, user: ApiObject, timestamp: str, chosen_zone_name: str, query: str,
-                           choosing_seconds: float):
+    def _save_chosen_result(self, user: ApiObject, timestamp: str, chosen_zone_name: str, query: str,
+                            choosing_seconds: float):
         # the query might have been retrieved from server-side cache and the user could be unknown for us
         self._save_user(user)
         self.data_source.save_chosen_result(user.id, timestamp, chosen_zone_name, query, choosing_seconds)

--- a/clock/storage/api.py
+++ b/clock/storage/api.py
@@ -31,5 +31,7 @@ class StorageApi:
 
     def save_chosen_result(self, user: ApiObject, timestamp: str, chosen_zone_name: str, query: str,
                            choosing_seconds: float):
+        # the query might have been retrieved from server-side cache and the user could be unknown for us
+        self._save_user(user)
         self.data_source.save_chosen_result(user.id, timestamp, chosen_zone_name, query, choosing_seconds)
         self.data_source.commit()

--- a/clock/storage/api.py
+++ b/clock/storage/api.py
@@ -4,19 +4,9 @@ from bot.api.domain import ApiObject
 from clock.domain.time import TimePoint
 from clock.storage.async.scheduler import StorageScheduler
 from clock.storage.data_source.data_source import StorageDataSource
-from clock.storage.data_source.data_sources.sqlite import SqliteStorageDataSource
 
 
 class StorageApi:
-    _instance = None
-
-    @classmethod
-    def get(cls):
-        """:rtype: StorageApi"""
-        if cls._instance is None:
-            cls._instance = StorageApi(SqliteStorageDataSource())
-        return cls._instance
-
     def __init__(self, data_source: StorageDataSource, scheduler: StorageScheduler):
         self.data_source = data_source
         self.scheduler = scheduler

--- a/clock/storage/api.py
+++ b/clock/storage/api.py
@@ -10,6 +10,10 @@ class StorageApi:
     def __init__(self, data_source: StorageDataSource, scheduler: StorageScheduler):
         self.data_source = data_source
         self.scheduler = scheduler
+        self.init()
+
+    def init(self):
+        self.scheduler.schedule_no_result(self._init)
 
     def save_query(self, query: ApiObject, time_point: TimePoint, locale: Locale, results_found: list,
                    results_sent: list, processing_seconds: float):
@@ -22,6 +26,9 @@ class StorageApi:
         self.scheduler.schedule_no_result(
             lambda: self._save_chosen_result(user, timestamp, chosen_zone_name, query, choosing_seconds)
         )
+
+    def _init(self):
+        self.data_source.init()
 
     def _save_query(self, query: ApiObject, time_point: TimePoint, locale: Locale, results_found: list,
                     results_sent: list, processing_seconds: float):

--- a/clock/storage/async/operation.py
+++ b/clock/storage/async/operation.py
@@ -1,0 +1,34 @@
+import queue
+
+from bot.multithreading.work import Work
+from bot.multithreading.worker import Worker
+
+
+class StorageOperation:
+    def __init__(self, worker: Worker, func: callable, ignore_result: bool):
+        self.worker = worker
+        self.func = func
+        self.ignore_result = ignore_result
+        self.result_queue = queue.Queue() if not ignore_result else None
+
+    def execute(self):
+        work = self._get_work()
+        self.worker.post(work)
+        if not self.ignore_result:
+            # block until result is obtained, and return it
+            return self.result_queue.get()
+
+    def _get_work(self):
+        func = self._wrapper_func
+        name = "storage_operation"
+        return Work(func, name)
+
+    def _wrapper_func(self):
+        result = None
+        try:
+            result = self.func()
+        finally:
+            if not self.ignore_result:
+                # always put a result, even if the operation crashes,
+                # to avoid caller from getting deadlocked waiting for the result
+                self.result_queue.put(result)

--- a/clock/storage/async/scheduler.py
+++ b/clock/storage/async/scheduler.py
@@ -1,0 +1,17 @@
+from bot.multithreading.worker import Worker
+
+from clock.storage.async.operation import StorageOperation
+
+
+class StorageScheduler:
+    def __init__(self, worker: Worker):
+        self.worker = worker
+
+    def schedule_no_result(self, func: callable):
+        return self._schedule(func, ignore_result=True)
+
+    def schedule_with_result(self, func: callable):
+        return self._schedule(func, ignore_result=False)
+
+    def _schedule(self, func: callable, ignore_result: bool):
+        return StorageOperation(self.worker, func, ignore_result).execute()

--- a/clock/storage/data_source/data_source.py
+++ b/clock/storage/data_source/data_source.py
@@ -1,4 +1,7 @@
 class StorageDataSource:
+    def init(self):
+        raise NotImplementedError()
+
     def save_query(self, user_id: int, timestamp: str, query: str, offset: str, locale: str, results_found_len: int,
                    results_sent_len: int, processing_seconds: float):
         raise NotImplementedError()

--- a/clock/storage/data_source/data_sources/sqlite.py
+++ b/clock/storage/data_source/data_sources/sqlite.py
@@ -10,6 +10,10 @@ class SqliteStorageDataSource(StorageDataSource):
     version = 1
 
     def __init__(self):
+        # initialized in init to avoid creating sqlite objects outside the thread in which it will be operating
+        self.connection = None
+
+    def init(self):
         self.connection = sqlite3.connect(DATABASE_FILENAME)
         self.connection.row_factory = sqlite3.Row  # improved rows
         self._init_db()

--- a/clock/storage/factory.py
+++ b/clock/storage/factory.py
@@ -1,0 +1,21 @@
+from bot.multithreading.worker import Worker
+
+from clock.storage.api import StorageApi
+from clock.storage.async.scheduler import StorageScheduler
+from clock.storage.data_source.data_sources.sqlite import SqliteStorageDataSource
+
+
+class StorageApiFactory:
+    @classmethod
+    def with_worker(cls, worker: Worker):
+        data_source = cls._get_default_data_source()
+        scheduler = cls._get_scheduler_for(worker)
+        return StorageApi(data_source, scheduler)
+
+    @staticmethod
+    def _get_default_data_source():
+        return SqliteStorageDataSource()
+
+    @staticmethod
+    def _get_scheduler_for(worker: Worker):
+        return StorageScheduler(worker)


### PR DESCRIPTION
- make StorageApi async
- prepare to create future calls that need to return results

other:
- logger can reuse messages sent on the same second