### PR TITLE
Maintain a list of active chats

### DIFF
--- a/clock/bot/save/message.py
+++ b/clock/bot/save/message.py
@@ -12,4 +12,23 @@ class SaveMessageAction(Action):
         self.storage = self.cache.storage
 
     def process(self, event):
-        self.storage.save_message(event.message)
+        message = event.message
+        self.storage.save_message(message)
+        self._check_inactive(message)
+
+    def _check_inactive(self, message):
+        self._check_left_chat(message)
+        self._check_chat_migrated(message)
+
+    def _check_left_chat(self, message):
+        left_chat_member = message.left_chat_member
+        if left_chat_member is not None and left_chat_member.id == self.cache.bot_info.id:
+            from_ = message.from_
+            reason = "left, by: " + str(from_.id) if from_ is not None else "unknown"
+            self.storage.set_inactive_chat(message.chat, reason)
+
+    def _check_chat_migrated(self, message):
+        migrate_to_chat_id = message.migrate_to_chat_id
+        if migrate_to_chat_id is not None:
+            reason = "migrated to: " + str(migrate_to_chat_id)
+            self.storage.set_inactive_chat(message.chat, reason)

--- a/clock/storage/api.py
+++ b/clock/storage/api.py
@@ -37,6 +37,11 @@ class StorageApi:
             lambda: self._save_command(message, command, command_args)
         )
 
+    def set_inactive_chat(self, chat: ApiObject, reason: str):
+        self.scheduler.schedule_no_result(
+            lambda: self._set_inactive_chat(chat, reason)
+        )
+
     def _init(self):
         self.data_source.init()
 
@@ -65,6 +70,7 @@ class StorageApi:
             self._save_user(user)
         chat = message.chat
         self._save_chat(chat)
+        self._set_active_chat(chat)
         self.data_source.save_message(chat.id, message.message_id, user_id, message.date, message.text)
         self.data_source.commit()
 
@@ -74,4 +80,11 @@ class StorageApi:
     def _save_command(self, message: ApiObject, command: str, command_args: str):
         message_id = self.data_source.get_message_id(message.chat.id, message.message_id)
         self.data_source.save_command(message_id, command, command_args)
+        self.data_source.commit()
+
+    def _set_active_chat(self, chat: ApiObject):
+        self.data_source.set_active_chat(chat.id)
+
+    def _set_inactive_chat(self, chat: ApiObject, reason: str):
+        self.data_source.set_inactive_chat(chat.id, reason)
         self.data_source.commit()

--- a/clock/storage/data_source/data_source.py
+++ b/clock/storage/data_source/data_source.py
@@ -25,5 +25,11 @@ class StorageDataSource:
     def save_user(self, user_id: int, first_name: str, last_name: str, username: str, language_code: str):
         raise NotImplementedError()
 
+    def set_active_chat(self, chat_id: int):
+        raise NotImplementedError()
+
+    def set_inactive_chat(self, chat_id: int, reason: str):
+        raise NotImplementedError()
+
     def commit(self):
         raise NotImplementedError()

--- a/clock/storage/data_source/data_sources/sqlite/component/components/active_chat.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/components/active_chat.py
@@ -1,0 +1,48 @@
+from clock.storage.data_source.data_sources.sqlite.component.component import SqliteStorageComponent
+
+
+class ActiveChatSqliteComponent(SqliteStorageComponent):
+    def init(self):
+        self._sql("create table if not exists active_chat ("
+                  "chat_id integer primary key not null,"
+                  "timestamp_added text"
+                  ")")
+        self._sql("create table if not exists inactive_chat ("
+                  "chat_id integer not null,"
+                  "inactive_reason text,"
+                  "timestamp_added text,"
+                  "timestamp_removed text"
+                  ")")
+
+    def set_active(self, chat_id: int):
+        self._sql("insert or ignore into active_chat "
+                  "(chat_id, timestamp_added) "
+                  "values (?, strftime('%s', 'now'))",
+                  (chat_id,))
+
+    def set_inactive(self, chat_id: int, reason: str):
+        if self.is_active(chat_id):
+            # insert into inactive from active
+            self._sql("insert into inactive_chat "
+                      "(chat_id, inactive_reason, timestamp_added, timestamp_removed) "
+                      "select chat_id, ?, timestamp_added, strftime('%s', 'now') "
+                      "from active_chat where chat_id = ?",
+                      (reason, chat_id,))
+            # now remove the active row
+            self._delete_active_chat(chat_id)
+        else:
+            # add to inactive with timestamp_added set to null
+            self._sql("insert into inactive_chat "
+                      "(chat_id, inactive_reason, timestamp_added, timestamp_removed) "
+                      "values (?, ?, null, strftime('%s', 'now'))",
+                      (chat_id, reason))
+
+    def is_active(self, chat_id: int):
+        return self._sql("select 1 from active_chat where "
+                         "chat_id = ?",
+                         (chat_id,)).fetchone() is not None
+
+    def _delete_active_chat(self, chat_id: int):
+        self._sql("delete from active_chat "
+                  "where chat_id = ?",
+                  (chat_id,))

--- a/clock/storage/data_source/data_sources/sqlite/component/factory.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/factory.py
@@ -1,5 +1,6 @@
 from sqlite3 import Connection
 
+from clock.storage.data_source.data_sources.sqlite.component.components.active_chat import ActiveChatSqliteComponent
 from clock.storage.data_source.data_sources.sqlite.component.components.chat import ChatSqliteComponent
 from clock.storage.data_source.data_sources.sqlite.component.components.message import MessageSqliteComponent
 from clock.storage.data_source.data_sources.sqlite.component.components.query import QuerySqliteComponent
@@ -21,3 +22,6 @@ class SqliteStorageComponentFactory:
 
     def message(self):
         return MessageSqliteComponent(self.connection)
+
+    def active_chat(self):
+        return ActiveChatSqliteComponent(self.connection)

--- a/clock/storage/data_source/data_sources/sqlite/sqlite.py
+++ b/clock/storage/data_source/data_sources/sqlite/sqlite.py
@@ -2,6 +2,7 @@ import sqlite3
 
 from clock.storage.data_source.data_source import StorageDataSource
 from clock.storage.data_source.data_sources.sqlite.component.component import SqliteStorageComponent
+from clock.storage.data_source.data_sources.sqlite.component.components.active_chat import ActiveChatSqliteComponent
 from clock.storage.data_source.data_sources.sqlite.component.components.chat import ChatSqliteComponent
 from clock.storage.data_source.data_sources.sqlite.component.components.message import MessageSqliteComponent
 from clock.storage.data_source.data_sources.sqlite.component.components.query import QuerySqliteComponent
@@ -20,6 +21,7 @@ class SqliteStorageDataSource(StorageDataSource):
         self.chat = None  # type: ChatSqliteComponent
         self.query = None  # type: QuerySqliteComponent
         self.message = None  # type: MessageSqliteComponent
+        self.active_chat = None  # type: ActiveChatSqliteComponent
 
     def init(self):
         self.connection = sqlite3.connect(DATABASE_FILENAME)
@@ -29,6 +31,7 @@ class SqliteStorageDataSource(StorageDataSource):
         self.chat = self._get_and_init(components.chat())
         self.query = self._get_and_init(components.query())
         self.message = self._get_and_init(components.message())
+        self.active_chat = self._get_and_init(components.active_chat())
 
     @staticmethod
     def _get_and_init(component: SqliteStorageComponent):
@@ -55,6 +58,12 @@ class SqliteStorageDataSource(StorageDataSource):
 
     def get_message_id(self, *args):
         return self.message.get_message_id(*args)
+
+    def set_active_chat(self, *args):
+        return self.active_chat.set_active(*args)
+
+    def set_inactive_chat(self, *args):
+        return self.active_chat.set_inactive(*args)
 
     def commit(self):
         self.connection.commit()


### PR DESCRIPTION
- new active chat sqlite component
- chats where the bot receive messages are considered active
- when the bot leaves a group (or is kicked) or a chat is migrated (to a supergroup), the chat is considered inactive (in the case of a migration, only the old chat)

- 100 additions and 1 deletion :open_mouth: 