### PR TITLE
Update telegram-bot-framework to 3.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 -e .
 
-telegram-bot-framework==v03.04.00
+telegram-bot-framework==v03.05.00


### PR DESCRIPTION
To fix a bug in the access of `SchedulerApi.io_worker` without being safe to use it from outside directly