### PR TITLE
Save more fields from messages

### DIFF
--- a/clock/bot/inline/query/action.py
+++ b/clock/bot/inline/query/action.py
@@ -26,7 +26,7 @@ class InlineQueryClockAction(Action):
         self.logger = LogApi.get(self.cache.logger)
         initial_locales_to_cache = self.config.locales_to_cache_on_startup
         self.locale_cache = LocaleCache(self.zone_finder.cache(), self.scheduler, self.logger, initial_locales_to_cache)
-        self.storage = StorageApiFactory.with_worker(self.scheduler.io_worker)
+        self.storage = StorageApiFactory.with_worker(self.scheduler.io_worker, self.config.debug())
         # for others to use
         self.cache.zone_finder = self.zone_finder
         self.cache.log_api = self.logger

--- a/clock/bot/manager.py
+++ b/clock/bot/manager.py
@@ -1,7 +1,7 @@
 from bot.action.core.action import ActionGroup
 from bot.action.core.command import CommandAction
 from bot.action.core.filter import MessageAction, TextMessageAction, NoPendingAction, PendingAction, InlineQueryAction, \
-    ChosenInlineResultAction
+    ChosenInlineResultAction, EditedMessageAction
 from bot.action.standard.about import AboutAction, VersionAction
 from bot.action.standard.admin import RestartAction, EvalAction, AdminActionWithErrorMessage, HaltAction
 from bot.action.standard.admin.config_status import ConfigStatusAction
@@ -48,6 +48,10 @@ class BotManager:
 
                     ChosenInlineResultAction().then(
                         ChosenInlineResultClockAction()
+                    ),
+
+                    EditedMessageAction().then(
+                        SaveMessageAction()
                     ),
 
                     MessageAction().then(

--- a/clock/bot/save/message.py
+++ b/clock/bot/save/message.py
@@ -23,12 +23,9 @@ class SaveMessageAction(Action):
     def _check_left_chat(self, message):
         left_chat_member = message.left_chat_member
         if left_chat_member is not None and left_chat_member.id == self.cache.bot_info.id:
-            from_ = message.from_
-            reason = "left, by: " + str(from_.id) if from_ is not None else "unknown"
-            self.storage.set_inactive_chat(message.chat, reason)
+            self.storage.set_inactive_chat(message.chat, "left")
 
     def _check_chat_migrated(self, message):
         migrate_to_chat_id = message.migrate_to_chat_id
         if migrate_to_chat_id is not None:
-            reason = "migrated to: " + str(migrate_to_chat_id)
-            self.storage.set_inactive_chat(message.chat, reason)
+            self.storage.set_inactive_chat(message.chat, "migrated")

--- a/clock/storage/api.py
+++ b/clock/storage/api.py
@@ -70,14 +70,33 @@ class StorageApi:
         chat = message.chat
         self._save_chat(chat)
         self._set_active_chat(chat)
-        self.data_source.save_message(
-            chat.id,
-            message.message_id,
-            user_id,
-            message.date,
-            message.text,
-            message.migrate_from_chat_id
-        )
+        is_forward = bool(message.forward_date)
+        reply_to_message = message.reply_to_message
+        if reply_to_message:
+            reply_to_message = reply_to_message.message_id
+        is_edit = bool(message.edit_date)
+        left_chat_member = message.left_chat_member
+        if left_chat_member:
+            left_chat_member = left_chat_member.id
+        new_chat_members = message.new_chat_members or [None]
+        for new_chat_member in new_chat_members:
+            if new_chat_member:
+                new_chat_member = new_chat_member.id
+            self.data_source.save_message(
+                chat.id,
+                message.message_id,
+                user_id,
+                message.date,
+                is_forward,
+                reply_to_message,
+                is_edit,
+                message.text,
+                new_chat_member,
+                left_chat_member,
+                message.group_chat_created,
+                message.migrate_to_chat_id,
+                message.migrate_from_chat_id
+            )
 
     def _save_chat(self, chat: ApiObject):
         self.data_source.save_chat(chat.id, chat.type, chat.title, chat.username)

--- a/clock/storage/api.py
+++ b/clock/storage/api.py
@@ -70,11 +70,11 @@ class StorageApi:
         chat = message.chat
         self._save_chat(chat)
         self._set_active_chat(chat)
-        is_forward = bool(message.forward_date)
+        is_forward = True if message.forward_date is not None else None
         reply_to_message = message.reply_to_message
         if reply_to_message:
             reply_to_message = reply_to_message.message_id
-        is_edit = bool(message.edit_date)
+        is_edit = True if message.edit_date is not None else None
         left_chat_member = message.left_chat_member
         if left_chat_member:
             left_chat_member = left_chat_member.id

--- a/clock/storage/api.py
+++ b/clock/storage/api.py
@@ -71,7 +71,14 @@ class StorageApi:
         chat = message.chat
         self._save_chat(chat)
         self._set_active_chat(chat)
-        self.data_source.save_message(chat.id, message.message_id, user_id, message.date, message.text)
+        self.data_source.save_message(
+            chat.id,
+            message.message_id,
+            user_id,
+            message.date,
+            message.text,
+            message.migrate_from_chat_id
+        )
         self.data_source.commit()
 
     def _save_chat(self, chat: ApiObject):

--- a/clock/storage/data_source/data_source.py
+++ b/clock/storage/data_source/data_source.py
@@ -13,8 +13,9 @@ class StorageDataSource:
     def save_command(self, message_id: int, command: str, command_args: str):
         raise NotImplementedError()
 
-    def save_message(self, chat_id: int, message_id: int, user_id: int, date: int, text: str,
-                     migrate_from_chat_id: int):
+    def save_message(self, chat_id: int, message_id: int, user_id: int, date: int, is_forward: bool,
+                     reply_to_message: int, is_edit: bool, text: str, new_chat_member: int, left_chat_member: int,
+                     group_chat_created: bool, migrate_to_chat_id: int, migrate_from_chat_id: int):
         raise NotImplementedError()
 
     def get_message_id(self, chat_id: int, message_id: int):

--- a/clock/storage/data_source/data_source.py
+++ b/clock/storage/data_source/data_source.py
@@ -13,7 +13,8 @@ class StorageDataSource:
     def save_command(self, message_id: int, command: str, command_args: str):
         raise NotImplementedError()
 
-    def save_message(self, chat_id: int, message_id: int, user_id: int, date: int, text: str):
+    def save_message(self, chat_id: int, message_id: int, user_id: int, date: int, text: str,
+                     migrate_from_chat_id: int):
         raise NotImplementedError()
 
     def get_message_id(self, chat_id: int, message_id: int):

--- a/clock/storage/data_source/data_sources/sqlite/component/component.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/component.py
@@ -16,8 +16,15 @@ class SqliteStorageComponent:
     def _sql(self, sql: str, params=()):
         return self.connection.execute(sql, params)
 
-    def sql(self, sql: str, *params):
-        return self.connection.execute(sql, params)
+    def sql(self, sql: str, *qmark_params, **named_params):
+        there_are_qmark_params = len(qmark_params) > 0
+        there_are_named_params = len(named_params) > 0
+        if there_are_qmark_params and there_are_named_params:
+            raise Exception("all params must be of the same type (qmark or named) for a single query")
+        params = qmark_params
+        if there_are_named_params:
+            params = named_params
+        return self._sql(sql, params)
 
     @staticmethod
     def _empty_if_none(field: str):

--- a/clock/storage/data_source/data_sources/sqlite/component/component.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/component.py
@@ -13,9 +13,6 @@ class SqliteStorageComponent:
     def create(self):
         raise NotImplementedError()
 
-    def _sql(self, sql: str, params=()):
-        return self.connection.execute(sql, params)
-
     def sql(self, sql: str, *qmark_params, **named_params):
         there_are_qmark_params = len(qmark_params) > 0
         there_are_named_params = len(named_params) > 0
@@ -25,6 +22,9 @@ class SqliteStorageComponent:
         if there_are_named_params:
             params = named_params
         return self._sql(sql, params)
+
+    def _sql(self, sql: str, params=()):
+        return self.connection.execute(sql, params)
 
     @staticmethod
     def _empty_if_none(field: str):

--- a/clock/storage/data_source/data_sources/sqlite/component/components/message.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/components/message.py
@@ -2,7 +2,7 @@ from clock.storage.data_source.data_sources.sqlite.component.component import Sq
 
 
 class MessageSqliteComponent(SqliteStorageComponent):
-    version = 1
+    version = 2
 
     def __init__(self):
         super().__init__("message", self.version)
@@ -15,13 +15,18 @@ class MessageSqliteComponent(SqliteStorageComponent):
                   "message_id integer,"
                   "user_id integer,"
                   "date integer,"
-                  "text text"
+                  "text text,"
+                  "migrate_from_chat_id integer"
                   ")")
         self._sql("create table if not exists command ("
                   "message_id integer,"
                   "command text,"
                   "command_args text"
                   ")")
+
+    def upgrade_from_1_to_2(self):
+        self.sql("alter table message "
+                 "add column migrate_from_chat_id integer")
 
     def save_message(self, chat_id: int, message_id: int, user_id: int, date: int, text: str):
         self._sql("insert into message "

--- a/clock/storage/data_source/data_sources/sqlite/component/components/message.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/components/message.py
@@ -32,8 +32,19 @@ class MessageSqliteComponent(SqliteStorageComponent):
                   ")")
 
     def upgrade_from_1_to_2(self):
-        self.sql("alter table message "
-                 "add column migrate_from_chat_id integer")
+        self._add_columns(
+            "message",
+            "is_forward integer", "reply_to_message integer", "is_edit integer",
+            "new_chat_member integer", "left_chat_member integer",
+            "group_chat_created integer", "migrate_to_chat_id integer", "migrate_from_chat_id integer"
+        )
+
+    def _add_columns(self, table: str, *columns: str):
+        for column in columns:
+            # table names and column definitions cannot be safely parametrized
+            # but as the caller is safe, we can format them in an unsafely way
+            sql = "alter table {table} add column {column}".format(table=table, column=column)
+            self.sql(sql)
 
     def save_message(self, chat_id: int, message_id: int, user_id: int, date: int, text: str, migrate_from_chat_id: int):
         self._sql("insert into message "

--- a/clock/storage/data_source/data_sources/sqlite/component/components/message.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/components/message.py
@@ -28,11 +28,11 @@ class MessageSqliteComponent(SqliteStorageComponent):
         self.sql("alter table message "
                  "add column migrate_from_chat_id integer")
 
-    def save_message(self, chat_id: int, message_id: int, user_id: int, date: int, text: str):
+    def save_message(self, chat_id: int, message_id: int, user_id: int, date: int, text: str, migrate_from_chat_id: int):
         self._sql("insert into message "
-                  "(timestamp, chat_id, message_id, user_id, date, text) "
-                  "values (strftime('%s', 'now'), ?, ?, ?, ?, ?)",
-                  (chat_id, message_id, user_id, date, text))
+                  "(timestamp, chat_id, message_id, user_id, date, text, migrate_from_chat_id) "
+                  "values (strftime('%s', 'now'), ?, ?, ?, ?, ?, ?)",
+                  (chat_id, message_id, user_id, date, text, migrate_from_chat_id))
 
     def save_command(self, message_id: int, command: str, command_args: str):
         self._sql("insert into command "

--- a/clock/storage/data_source/data_sources/sqlite/component/components/message.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/components/message.py
@@ -15,7 +15,14 @@ class MessageSqliteComponent(SqliteStorageComponent):
                   "message_id integer,"
                   "user_id integer,"
                   "date integer,"
+                  "is_forward integer,"  # boolean
+                  "reply_to_message integer,"  # references: message_id column
+                  "is_edit integer,"  # boolean
                   "text text,"
+                  "new_chat_member integer,"  # user_id
+                  "left_chat_member integer,"  # user_id
+                  "group_chat_created integer,"  # boolean
+                  "migrate_to_chat_id integer,"
                   "migrate_from_chat_id integer"
                   ")")
         self._sql("create table if not exists command ("

--- a/clock/storage/data_source/data_sources/sqlite/component/components/message.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/components/message.py
@@ -47,11 +47,15 @@ class MessageSqliteComponent(SqliteStorageComponent):
             sql = "alter table {table} add column {column}".format(table=table, column=column)
             self.sql(sql)
 
-    def save_message(self, chat_id: int, message_id: int, user_id: int, date: int, text: str, migrate_from_chat_id: int):
+    def save_message(self, chat_id: int, message_id: int, user_id: int, date: int, is_forward: bool,
+                     reply_to_message: int, is_edit: bool, text: str, new_chat_member: int, left_chat_member: int,
+                     group_chat_created: bool, migrate_to_chat_id: int, migrate_from_chat_id: int):
         self._sql("insert into message "
-                  "(timestamp, chat_id, message_id, user_id, date, text, migrate_from_chat_id) "
-                  "values (strftime('%s', 'now'), ?, ?, ?, ?, ?, ?)",
-                  (chat_id, message_id, user_id, date, text, migrate_from_chat_id))
+                  "(timestamp, chat_id, message_id, user_id, date, is_forward, reply_to_message, is_edit, text, "
+                  "new_chat_member, left_chat_member, group_chat_created, migrate_to_chat_id, migrate_from_chat_id) "
+                  "values (strftime('%s', 'now'), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                  (chat_id, message_id, user_id, date, is_forward, reply_to_message, is_edit, text, new_chat_member,
+                   left_chat_member, group_chat_created, migrate_to_chat_id, migrate_from_chat_id))
 
     def save_command(self, message_id: int, command: str, command_args: str):
         self._sql("insert into command "

--- a/clock/storage/data_source/data_sources/sqlite/component/components/message.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/components/message.py
@@ -41,8 +41,9 @@ class MessageSqliteComponent(SqliteStorageComponent):
 
     def _add_columns(self, table: str, *columns: str):
         for column in columns:
-            # table names and column definitions cannot be safely parametrized
-            # but as the caller is safe, we can format them in an unsafely way
+            # table name and column definitions cannot be (safely) parametrized by the sqlite engine
+            # but as we trust the input (the caller use hardcoded params),
+            # we can format the statement in an unsafe way
             sql = "alter table {table} add column {column}".format(table=table, column=column)
             self.sql(sql)
 

--- a/clock/storage/data_source/data_sources/sqlite/component/migrate/strategies/upgrade_or_downgrade.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/migrate/strategies/upgrade_or_downgrade.py
@@ -84,6 +84,6 @@ class NoMigratePathFoundException(SqliteComponentMigratorException):
     def __init__(self, component: SqliteStorageComponent, migration_type: str, old_version: int, new_version: int):
         super().__init__(
             component, migration_type,
-            "no valid path to fully {migration_type} from {old} to {new} version was found"
+            "no valid path to fully {migration_type} from version {old} to {new} was found"
             .format(migration_type=migration_type, old=old_version, new=new_version)
         )

--- a/clock/storage/data_source/data_sources/sqlite/sqlite.py
+++ b/clock/storage/data_source/data_sources/sqlite/sqlite.py
@@ -14,10 +14,11 @@ DATABASE_FILENAME = "state/clock.db"
 
 
 class SqliteStorageDataSource(StorageDataSource):
-    def __init__(self):
+    def __init__(self, debug: bool):
+        self.debug = debug
+        self.inside_pending_context_manager = False
         # initialized in init to avoid creating sqlite objects outside the thread in which it will be operating
         self.connection = None  # type: Connection
-        self.inside_pending_context_manager = False
         self.user = None  # type: UserSqliteComponent
         self.chat = None  # type: ChatSqliteComponent
         self.query = None  # type: QuerySqliteComponent
@@ -30,6 +31,9 @@ class SqliteStorageDataSource(StorageDataSource):
 
     def _init_connection(self):
         self.connection = sqlite3.connect(DATABASE_FILENAME)
+        if self.debug:
+            # print all sentences to stdout
+            self.connection.set_trace_callback(lambda x: print(x))
         # disable implicit transactions as we are manually handling them
         self.connection.isolation_level = None
         # improved rows

--- a/clock/storage/factory.py
+++ b/clock/storage/factory.py
@@ -7,14 +7,14 @@ from clock.storage.data_source.data_sources.sqlite.sqlite import SqliteStorageDa
 
 class StorageApiFactory:
     @classmethod
-    def with_worker(cls, worker: Worker):
-        data_source = cls._get_default_data_source()
+    def with_worker(cls, worker: Worker, debug: bool):
+        data_source = cls._get_default_data_source(debug)
         scheduler = cls._get_scheduler_for(worker)
         return StorageApi(data_source, scheduler)
 
     @staticmethod
-    def _get_default_data_source():
-        return SqliteStorageDataSource()
+    def _get_default_data_source(debug: bool):
+        return SqliteStorageDataSource(debug)
 
     @staticmethod
     def _get_scheduler_for(worker: Worker):


### PR DESCRIPTION
- new version 2 of message component
- add migrate from version 1 function
- sqlite data source will print statements to standard output if debug is enabled
- simplified reason in active_chat (the information can still be retrieved from message)
- new sql method which accepts both qmark and named style params