### PR TITLE
Run storage operations on context manager

### DIFF
--- a/clock/storage/api.py
+++ b/clock/storage/api.py
@@ -10,6 +10,7 @@ class StorageApi:
     def __init__(self, data_source: StorageDataSource, scheduler: StorageScheduler):
         self.data_source = data_source
         self.scheduler = scheduler
+        scheduler.set_context_manager(data_source.context_manager())
         self.init()
 
     def init(self):

--- a/clock/storage/api.py
+++ b/clock/storage/api.py
@@ -51,7 +51,6 @@ class StorageApi:
         self._save_user(query.from_)
         self.data_source.save_query(query.from_.id, time_point.id(), query.query, query.offset, str(locale),
                                     len(results_found), len(results_sent), processing_seconds)
-        self.data_source.commit()
 
     def _save_user(self, user: ApiObject):
         self.data_source.save_user(user.id, user.first_name, user.last_name, user.username, user.language_code)
@@ -61,7 +60,6 @@ class StorageApi:
         # the query might have been retrieved from server-side cache and the user could be unknown for us
         self._save_user(user)
         self.data_source.save_chosen_result(user.id, timestamp, chosen_zone_name, query, choosing_seconds)
-        self.data_source.commit()
 
     def _save_message(self, message: ApiObject):
         user_id = None
@@ -73,7 +71,6 @@ class StorageApi:
         self._save_chat(chat)
         self._set_active_chat(chat)
         self.data_source.save_message(chat.id, message.message_id, user_id, message.date, message.text)
-        self.data_source.commit()
 
     def _save_chat(self, chat: ApiObject):
         self.data_source.save_chat(chat.id, chat.type, chat.title, chat.username)
@@ -81,11 +78,9 @@ class StorageApi:
     def _save_command(self, message: ApiObject, command: str, command_args: str):
         message_id = self.data_source.get_message_id(message.chat.id, message.message_id)
         self.data_source.save_command(message_id, command, command_args)
-        self.data_source.commit()
 
     def _set_active_chat(self, chat: ApiObject):
         self.data_source.set_active_chat(chat.id)
 
     def _set_inactive_chat(self, chat: ApiObject, reason: str):
         self.data_source.set_inactive_chat(chat.id, reason)
-        self.data_source.commit()

--- a/clock/storage/async/operation.py
+++ b/clock/storage/async/operation.py
@@ -5,8 +5,9 @@ from bot.multithreading.worker import Worker
 
 
 class StorageOperation:
-    def __init__(self, worker: Worker, func: callable, ignore_result: bool):
+    def __init__(self, worker: Worker, context_manager, func: callable, ignore_result: bool):
         self.worker = worker
+        self.context_manager = context_manager
         self.func = func
         self.ignore_result = ignore_result
         self.result_queue = queue.Queue() if not ignore_result else None
@@ -26,9 +27,13 @@ class StorageOperation:
     def _wrapper_func(self):
         result = None
         try:
-            result = self.func()
+            result = self._run_func_in_context_manager()
         finally:
             if not self.ignore_result:
                 # always put a result, even if the operation crashes,
                 # to avoid caller from getting deadlocked waiting for the result
                 self.result_queue.put(result)
+
+    def _run_func_in_context_manager(self):
+        with self.context_manager:
+            return self.func()

--- a/clock/storage/async/scheduler.py
+++ b/clock/storage/async/scheduler.py
@@ -6,6 +6,10 @@ from clock.storage.async.operation import StorageOperation
 class StorageScheduler:
     def __init__(self, worker: Worker):
         self.worker = worker
+        self.context_manager = None
+
+    def set_context_manager(self, context_manager):
+        self.context_manager = context_manager
 
     def schedule_no_result(self, func: callable):
         return self._schedule(func, ignore_result=True)
@@ -14,4 +18,4 @@ class StorageScheduler:
         return self._schedule(func, ignore_result=False)
 
     def _schedule(self, func: callable, ignore_result: bool):
-        return StorageOperation(self.worker, func, ignore_result).execute()
+        return StorageOperation(self.worker, self.context_manager, func, ignore_result).execute()

--- a/clock/storage/data_source/data_source.py
+++ b/clock/storage/data_source/data_source.py
@@ -31,5 +31,5 @@ class StorageDataSource:
     def set_inactive_chat(self, chat_id: int, reason: str):
         raise NotImplementedError()
 
-    def commit(self):
+    def context_manager(self):
         raise NotImplementedError()

--- a/clock/storage/data_source/data_sources/sqlite/component/migrate/strategy.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/migrate/strategy.py
@@ -17,9 +17,8 @@ class SqliteMigrationStrategy:
         raise NotImplementedError()
 
     def do_migration(self, func: callable, to_version: int):
-        with self.component.connection:
-            func()
-            self.version_info.set_version(self.component.name, to_version)
+        func()
+        self.version_info.set_version(self.component.name, to_version)
 
     def get_migrate_func(self, name: str = None):
         if name is None:

--- a/clock/storage/data_source/data_sources/sqlite/sqlite.py
+++ b/clock/storage/data_source/data_sources/sqlite/sqlite.py
@@ -26,8 +26,14 @@ class SqliteStorageDataSource(StorageDataSource):
         self.active_chat = None  # type: ActiveChatSqliteComponent
 
     def init(self):
+        self._init_connection()
+        self._init_components()
+
+    def _init_connection(self):
         self.connection = sqlite3.connect(DATABASE_FILENAME)
         self.connection.row_factory = sqlite3.Row  # improved rows
+
+    def _init_components(self):
         components = SqliteStorageComponentFactory(self.connection)
         self.user = components.user()
         self.chat = components.chat()

--- a/clock/storage/data_source/data_sources/sqlite/sqlite.py
+++ b/clock/storage/data_source/data_sources/sqlite/sqlite.py
@@ -1,9 +1,7 @@
 import sqlite3
-
 from sqlite3 import Connection
 
 from clock.storage.data_source.data_source import StorageDataSource
-from clock.storage.data_source.data_sources.sqlite.component.component import SqliteStorageComponent
 from clock.storage.data_source.data_sources.sqlite.component.components.active_chat import ActiveChatSqliteComponent
 from clock.storage.data_source.data_sources.sqlite.component.components.chat import ChatSqliteComponent
 from clock.storage.data_source.data_sources.sqlite.component.components.message import MessageSqliteComponent

--- a/clock/storage/data_source/data_sources/sqlite/sqlite.py
+++ b/clock/storage/data_source/data_sources/sqlite/sqlite.py
@@ -32,8 +32,10 @@ class SqliteStorageDataSource(StorageDataSource):
 
     def _init_connection(self):
         self.connection = sqlite3.connect(DATABASE_FILENAME)
+        # disable implicit transactions as we are manually handling them
         self.connection.isolation_level = None
-        self.connection.row_factory = sqlite3.Row  # improved rows
+        # improved rows
+        self.connection.row_factory = sqlite3.Row
         if self.inside_pending_context_manager:
             self.__enter__()
 


### PR DESCRIPTION
In the sqlite implementation, the context manager will take care of starting and ending a transaction. It will commit it if it ends without error, or rollback it if an exception is raised inside the operation.
So, there is no more need for manual commit() calls.