### PR TITLE
Cache recent locales on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The recognised options are:
  - `locales_to_cache_on_startup`, that can have a space-separated or newline-separated list of locale codes to be cached on startup. By default, `en_US` and `es_ES` locales are cached.
  - `min_query_workers`, with the number of minimum workers that must be always ready to process inline requests. By default, 1 worker is always ready.
  - `max_query_workers`, with the number of maximum workers that can be spawned to process inline requests under heavy load situations. By default, 8 workers are allowed.
+ - `recent_locales_limit`, can be an integer specifying the maximum number of locales most recently used in queries that should be cached on startup. This number does not take into account the locales specified in `locales_to_cache_on_startup`. By default, the 10 most recent locales are cached.
 
 Once configured, you can run the `main.py` file directly, or the
 `run.sh` script that will set-up a virtual environment and install

--- a/clock/bot/inline/query/action.py
+++ b/clock/bot/inline/query/action.py
@@ -24,9 +24,13 @@ class InlineQueryClockAction(Action):
     def post_setup(self):
         self.zone_finder = ZoneFinderApi(bool(self.config.enable_countries))
         self.logger = LogApi.get(self.cache.logger)
-        initial_locales_to_cache = self.config.locales_to_cache_on_startup
-        self.locale_cache = LocaleCache(self.zone_finder.cache(), self.scheduler, self.logger, initial_locales_to_cache)
         self.storage = StorageApiFactory.with_worker(self.scheduler.io_worker, self.config.debug())
+        initial_locales_to_cache = self.config.locales_to_cache_on_startup
+        recent_locales_limit = self.config.recent_locales_limit
+        self.locale_cache = LocaleCache(
+            self.zone_finder.cache(), self.scheduler, self.logger, self.storage,
+            initial_locales_to_cache, recent_locales_limit
+        )
         # for others to use
         self.cache.zone_finder = self.zone_finder
         self.cache.log_api = self.logger

--- a/clock/bot/inline/query/result/generator.py
+++ b/clock/bot/inline/query/result/generator.py
@@ -29,7 +29,7 @@ class AnswerInlineQueryResultGenerator:
             "inline_query_id": query.id,
             "results": results,
             "next_offset": next_offset,
-            "cache_time": 0,
+            "cache_time": 1,  # same queries on the same second will return same results
             "is_personal": "true"
         }
         if len(results) == 0:

--- a/clock/bot/locale_cache.py
+++ b/clock/bot/locale_cache.py
@@ -15,13 +15,13 @@ es-ES
 
 
 class LocaleCache:
-    def __init__(self, zone_finder_locale_cache: ZoneFinderLocaleCache, scheduler: SchedulerApi, log_api: LogApi,
+    def __init__(self, zone_finder_locale_cache: ZoneFinderLocaleCache, scheduler: SchedulerApi, logger: LogApi,
                  initial_locales_to_cache: str):
         self.locale_cache = zone_finder_locale_cache
         # using only one background thread to avoid consuming too many resources for locale caching
         # this is a background cache, quickly processing queries is more important
         self.worker = scheduler.new_worker_pool("locale_cache", min_workers=0, max_workers=1, max_seconds_idle=60)
-        self.log_api = log_api
+        self.logger = logger
         self._cache_initial_locales(self._parse_initial_locales(initial_locales_to_cache))
 
     @staticmethod
@@ -46,7 +46,7 @@ class LocaleCache:
     def _cache(self, locale: Locale):
         start_time = TimePoint.current_timestamp()
         self.locale_cache.cache(locale)
-        self.log_api.log_locale_cache(locale, TimePoint.current_timestamp() - start_time)
+        self.logger.log_locale_cache(locale, TimePoint.current_timestamp() - start_time)
 
     def is_cached(self, locale: Locale):
         return self.locale_cache.is_cached(locale)

--- a/clock/bot/locale_cache.py
+++ b/clock/bot/locale_cache.py
@@ -22,12 +22,12 @@ class LocaleCache:
         # this is a background cache, quickly processing queries is more important
         self.worker = scheduler.new_worker_pool("locale_cache", min_workers=0, max_workers=1, max_seconds_idle=60)
         self.logger = logger
-        self._cache_initial_locales(self._parse_initial_locales(initial_locales_to_cache))
+        self._cache_initial_locales(self._parse_initial_locales(
+            initial_locales_to_cache or DEFAULT_INITIAL_LOCALES_TO_CACHE
+        ))
 
     @staticmethod
     def _parse_initial_locales(initial_locales_to_cache: str):
-        if initial_locales_to_cache is None:
-            initial_locales_to_cache = DEFAULT_INITIAL_LOCALES_TO_CACHE
         for line in initial_locales_to_cache.splitlines():
             for language_code in line.split():
                 if language_code.startswith("#"):

--- a/clock/storage/api.py
+++ b/clock/storage/api.py
@@ -48,6 +48,12 @@ class StorageApi:
             "set_inactive_chat"
         )
 
+    def get_recent_queries_language_codes(self, limit: int):
+        return self.scheduler.schedule_with_result(
+            lambda: self._get_recent_queries_language_codes(limit),
+            "get_recent_queries_language_codes"
+        )
+
     def _init(self):
         self.data_source.init()
 
@@ -120,3 +126,6 @@ class StorageApi:
 
     def _set_inactive_chat(self, chat: ApiObject, reason: str):
         self.data_source.set_inactive_chat(chat.id, reason)
+
+    def _get_recent_queries_language_codes(self, limit: int):
+        return self.data_source.get_recent_queries_language_codes(limit)

--- a/clock/storage/api.py
+++ b/clock/storage/api.py
@@ -53,9 +53,12 @@ class StorageApi:
 
     def _save_query(self, query: ApiObject, time_point: TimePoint, locale: Locale, results_found: list,
                     results_sent: list, processing_seconds: float):
-        self._save_user(query.from_)
-        self.data_source.save_query(query.from_.id, time_point.id(), query.query, query.offset, str(locale),
-                                    len(results_found), len(results_sent), processing_seconds)
+        user = query.from_
+        self._save_user(user)
+        self.data_source.save_query(
+            user.id, time_point.id(), query.query, query.offset, user.language_code, str(locale),
+            len(results_found), len(results_sent), processing_seconds
+        )
 
     def _save_user(self, user: ApiObject):
         self.data_source.save_user(user.id, user.first_name, user.last_name, user.username, user.language_code)

--- a/clock/storage/async/operation.py
+++ b/clock/storage/async/operation.py
@@ -43,6 +43,6 @@ class StorageOperation:
         is_blocking = "NO" if self.ignore_result else ""
         return ":".join([
             "storage_operation",
-            self.name,
-            is_blocking + "blocking"
+            is_blocking + "blocking",
+            self.name
         ])

--- a/clock/storage/data_source/data_source.py
+++ b/clock/storage/data_source/data_source.py
@@ -2,8 +2,8 @@ class StorageDataSource:
     def init(self):
         raise NotImplementedError()
 
-    def save_query(self, user_id: int, timestamp: str, query: str, offset: str, locale: str, results_found_len: int,
-                   results_sent_len: int, processing_seconds: float):
+    def save_query(self, user_id: int, timestamp: str, query: str, offset: str, language_code: str, locale: str,
+                   results_found_len: int, results_sent_len: int, processing_seconds: float):
         raise NotImplementedError()
 
     def save_chosen_result(self, user_id: int, timestamp: str, chosen_zone_name: str, query: str,

--- a/clock/storage/data_source/data_source.py
+++ b/clock/storage/data_source/data_source.py
@@ -33,5 +33,8 @@ class StorageDataSource:
     def set_inactive_chat(self, chat_id: int, reason: str):
         raise NotImplementedError()
 
+    def get_recent_queries_language_codes(self, limit: int):
+        raise NotImplementedError()
+
     def context_manager(self):
         raise NotImplementedError()

--- a/clock/storage/data_source/data_sources/sqlite/component/component.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/component.py
@@ -1,4 +1,5 @@
 from sqlite3 import Connection
+from typing import Iterable
 
 
 class SqliteStorageComponent:
@@ -12,6 +13,29 @@ class SqliteStorageComponent:
 
     def create(self):
         raise NotImplementedError()
+
+    def select(self, fields: Iterable[str] = ("*",), table: str = "",
+               where: str = "", other: str = "",
+               *qmark_params, **named_params):
+        """
+        IMPORTANT:
+        All arguments except qmark_params and named_params are added to the sql statement in an unsafe way!
+        So, untrusted input MUST NOT be passed to them.
+        Their values should ideally be static string literals.
+        If computed at runtime, they MUST come from a TOTALLY trusted source (like another module string constant
+        or an admin-controlled configuration value).
+        """
+        clauses = []
+        fields = ", ".join(fields)
+        clauses.append("select {fields}".format(fields=fields))  # unsafe formatting
+        if table:
+            clauses.append("from {table}".format(table=table))  # unsafe formatting
+        if where:
+            clauses.append("where {where}".format(where=where))  # unsafe formatting
+        if other:
+            clauses.append("{other}".format(other=other))  # unsafe formatting
+        sql = " ".join(clauses)
+        return self.sql(sql, *qmark_params, **named_params)
 
     def add_columns(self, table: str, *columns: str):
         """

--- a/clock/storage/data_source/data_sources/sqlite/component/component.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/component.py
@@ -37,6 +37,17 @@ class SqliteStorageComponent:
         sql = " ".join(clauses)
         return self.sql(sql, *qmark_params, **named_params)
 
+    def select_field_one(self, field: str, *args, **kwargs):
+        """
+        Return the field value for the first result.
+
+        IMPORTANT:
+        Same precautions as :func:`select` must be taken.
+        """
+        row = self.select(fields=(field,), *args, **kwargs).fetchone()
+        if row:
+            return row[field]
+
     def add_columns(self, table: str, *columns: str):
         """
         IMPORTANT:

--- a/clock/storage/data_source/data_sources/sqlite/component/component.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/component.py
@@ -43,6 +43,15 @@ class SqliteStorageComponent:
         sql = " ".join(clauses)
         return self.sql(sql, *qmark_params, **named_params)
 
+    def select_field(self, field: str, *args, **kwargs):
+        """
+        Return a list with the field values for the query.
+
+        IMPORTANT:
+        Same precautions as :func:`select` must be taken.
+        """
+        return (row[field] for row in self.select(fields=(field,), *args, **kwargs))
+
     def select_field_one(self, field: str, *args, **kwargs):
         """
         Return the field value for the first result.

--- a/clock/storage/data_source/data_sources/sqlite/component/component.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/component.py
@@ -15,7 +15,7 @@ class SqliteStorageComponent:
         raise NotImplementedError()
 
     def select(self, fields: Iterable[str] = ("*",), table: str = "",
-               where: str = "", order_by: str = "", other: str = "",
+               where: str = "", group_by: str = "", order_by: str = "", limit: int = None, other: str = "",
                *qmark_params, **named_params):
         """
         IMPORTANT:
@@ -32,8 +32,12 @@ class SqliteStorageComponent:
             clauses.append("from {table}".format(table=table))  # unsafe formatting
         if where:
             clauses.append("where {where}".format(where=where))  # unsafe formatting
+        if group_by:
+            clauses.append("group by {group_by}".format(group_by=group_by))  # unsafe formatting
         if order_by:
             clauses.append("order by {order_by}".format(order_by=order_by))  # unsafe formatting
+        if limit:
+            clauses.append("limit {limit}".format(limit=limit))  # unsafe formatting
         if other:
             clauses.append("{other}".format(other=other))  # unsafe formatting
         sql = " ".join(clauses)

--- a/clock/storage/data_source/data_sources/sqlite/component/component.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/component.py
@@ -13,6 +13,14 @@ class SqliteStorageComponent:
     def create(self):
         raise NotImplementedError()
 
+    def _add_columns(self, table: str, *columns: str):
+        for column in columns:
+            # table name and column definitions cannot be (safely) parametrized by the sqlite engine
+            # but as we trust the input (the caller use hardcoded params),
+            # we can format the statement in an unsafe way
+            sql = "alter table {table} add column {column}".format(table=table, column=column)
+            self.sql(sql)
+
     def sql(self, sql: str, *qmark_params, **named_params):
         there_are_qmark_params = len(qmark_params) > 0
         there_are_named_params = len(named_params) > 0

--- a/clock/storage/data_source/data_sources/sqlite/component/component.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/component.py
@@ -14,10 +14,17 @@ class SqliteStorageComponent:
         raise NotImplementedError()
 
     def _add_columns(self, table: str, *columns: str):
+        """
+        IMPORTANT:
+        Table name and column definitions are added to the sql statement in an unsafe way!
+        So, untrusted input MUST NOT be passed to them.
+        Their values should ideally be static string literals.
+        If computed at runtime, they MUST come from a TOTALLY trusted source (like another module string constant
+        or an admin-controlled configuration value).
+        """
         for column in columns:
             # table name and column definitions cannot be (safely) parametrized by the sqlite engine
-            # but as we trust the input (the caller use hardcoded params),
-            # we can format the statement in an unsafe way
+            # but as we trust the input, we can format the statement in an unsafe way
             sql = "alter table {table} add column {column}".format(table=table, column=column)
             self.sql(sql)
 

--- a/clock/storage/data_source/data_sources/sqlite/component/component.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/component.py
@@ -15,7 +15,7 @@ class SqliteStorageComponent:
         raise NotImplementedError()
 
     def select(self, fields: Iterable[str] = ("*",), table: str = "",
-               where: str = "", other: str = "",
+               where: str = "", order_by: str = "", other: str = "",
                *qmark_params, **named_params):
         """
         IMPORTANT:
@@ -32,6 +32,8 @@ class SqliteStorageComponent:
             clauses.append("from {table}".format(table=table))  # unsafe formatting
         if where:
             clauses.append("where {where}".format(where=where))  # unsafe formatting
+        if order_by:
+            clauses.append("order by {order_by}".format(order_by=order_by))  # unsafe formatting
         if other:
             clauses.append("{other}".format(other=other))  # unsafe formatting
         sql = " ".join(clauses)

--- a/clock/storage/data_source/data_sources/sqlite/component/component.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/component.py
@@ -14,8 +14,8 @@ class SqliteStorageComponent:
     def create(self):
         raise NotImplementedError()
 
-    def select(self, fields: Iterable[str] = ("*",), table: str = "",
-               where: str = "", group_by: str = "", order_by: str = "", limit: int = None, other: str = "",
+    def select(self, fields: Iterable[str] = ("*",), table: str = None,
+               where: str = None, group_by: str = None, order_by: str = None, limit: int = None, other: str = None,
                *qmark_params, **named_params):
         """
         IMPORTANT:
@@ -28,17 +28,17 @@ class SqliteStorageComponent:
         clauses = []
         fields = ", ".join(fields)
         clauses.append("select {fields}".format(fields=fields))  # unsafe formatting
-        if table:
+        if table is not None:
             clauses.append("from {table}".format(table=table))  # unsafe formatting
-        if where:
+        if where is not None:
             clauses.append("where {where}".format(where=where))  # unsafe formatting
-        if group_by:
+        if group_by is not None:
             clauses.append("group by {group_by}".format(group_by=group_by))  # unsafe formatting
-        if order_by:
+        if order_by is not None:
             clauses.append("order by {order_by}".format(order_by=order_by))  # unsafe formatting
-        if limit:
+        if limit is not None:
             clauses.append("limit {limit}".format(limit=limit))  # unsafe formatting
-        if other:
+        if other is not None:
             clauses.append("{other}".format(other=other))  # unsafe formatting
         sql = " ".join(clauses)
         return self.sql(sql, *qmark_params, **named_params)

--- a/clock/storage/data_source/data_sources/sqlite/component/component.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/component.py
@@ -13,7 +13,7 @@ class SqliteStorageComponent:
     def create(self):
         raise NotImplementedError()
 
-    def _add_columns(self, table: str, *columns: str):
+    def add_columns(self, table: str, *columns: str):
         """
         IMPORTANT:
         Table name and column definitions are added to the sql statement in an unsafe way!

--- a/clock/storage/data_source/data_sources/sqlite/component/components/message.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/components/message.py
@@ -32,7 +32,7 @@ class MessageSqliteComponent(SqliteStorageComponent):
                   ")")
 
     def upgrade_from_1_to_2(self):
-        self._add_columns(
+        self.add_columns(
             "message",
             "is_forward integer", "reply_to_message integer", "is_edit integer",
             "new_chat_member integer", "left_chat_member integer",

--- a/clock/storage/data_source/data_sources/sqlite/component/components/message.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/components/message.py
@@ -39,14 +39,6 @@ class MessageSqliteComponent(SqliteStorageComponent):
             "group_chat_created integer", "migrate_to_chat_id integer", "migrate_from_chat_id integer"
         )
 
-    def _add_columns(self, table: str, *columns: str):
-        for column in columns:
-            # table name and column definitions cannot be (safely) parametrized by the sqlite engine
-            # but as we trust the input (the caller use hardcoded params),
-            # we can format the statement in an unsafe way
-            sql = "alter table {table} add column {column}".format(table=table, column=column)
-            self.sql(sql)
-
     def save_message(self, chat_id: int, message_id: int, user_id: int, date: int, is_forward: bool,
                      reply_to_message: int, is_edit: bool, text: str, new_chat_member: int, left_chat_member: int,
                      group_chat_created: bool, migrate_to_chat_id: int, migrate_from_chat_id: int):

--- a/clock/storage/data_source/data_sources/sqlite/component/components/query.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/components/query.py
@@ -31,6 +31,19 @@ class QuerySqliteComponent(SqliteStorageComponent):
                   "choosing_seconds real"
                   ")")
 
+    def upgrade_from_1_to_2(self):
+        self.add_columns("query", "language_code text")
+        queries = self.select(fields=("rowid", "user_id", "timestamp"), table="query")  # get all queries
+        for query in queries:
+            rowid = query["rowid"]
+            user_id = query["user_id"]
+            timestamp = query["timestamp"]
+            language_code = self.user.get_user_language_code_at(user_id, timestamp)
+            self.sql("update query "
+                     "set language_code = :language_code "
+                     "where rowid = :rowid",
+                     language_code=language_code, rowid=rowid)
+
     def save_query(self, user_id: int, timestamp: str, query: str, offset: str, language_code: str, locale: str,
                    results_found_len: int, results_sent_len: int, processing_seconds: float):
         self._sql("insert into query "

--- a/clock/storage/data_source/data_sources/sqlite/component/components/query.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/components/query.py
@@ -3,7 +3,7 @@ from clock.storage.data_source.data_sources.sqlite.component.components.user imp
 
 
 class QuerySqliteComponent(SqliteStorageComponent):
-    version = 1
+    version = 2
 
     def __init__(self, user: UserSqliteComponent):
         super().__init__("query", self.version)
@@ -16,6 +16,7 @@ class QuerySqliteComponent(SqliteStorageComponent):
                   "time_point text not null,"
                   "query text,"
                   "offset text,"
+                  "language_code text,"
                   "locale text,"
                   "results_found_len integer,"
                   "results_sent_len integer,"
@@ -30,13 +31,14 @@ class QuerySqliteComponent(SqliteStorageComponent):
                   "choosing_seconds real"
                   ")")
 
-    def save_query(self, user_id: int, timestamp: str, query: str, offset: str, locale: str, results_found_len: int,
-                   results_sent_len: int, processing_seconds: float):
+    def save_query(self, user_id: int, timestamp: str, query: str, offset: str, language_code: str, locale: str,
+                   results_found_len: int, results_sent_len: int, processing_seconds: float):
         self._sql("insert into query "
-                  "(timestamp, user_id, time_point, query, offset, locale, results_found_len, results_sent_len, "
-                  "processing_seconds) "
-                  "values (strftime('%s', 'now'), ?, ?, ?, ?, ?, ?, ?, ?)",
-                  (user_id, timestamp, query, offset, locale, results_found_len, results_sent_len, processing_seconds))
+                  "(timestamp, user_id, time_point, query, offset, language_code, locale, results_found_len, "
+                  "results_sent_len, processing_seconds) "
+                  "values (strftime('%s', 'now'), ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                  (user_id, timestamp, query, offset, language_code, locale, results_found_len, results_sent_len,
+                   processing_seconds))
 
     def save_chosen_result(self, user_id: int, timestamp: str, chosen_zone_name: str, query: str,
                            choosing_seconds: float):

--- a/clock/storage/data_source/data_sources/sqlite/component/components/query.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/components/query.py
@@ -59,3 +59,12 @@ class QuerySqliteComponent(SqliteStorageComponent):
                   "(timestamp, user_id, time_point, chosen_zone_name, query, choosing_seconds) "
                   "values (strftime('%s', 'now'), ?, ?, ?, ?, ?)",
                   (user_id, timestamp, chosen_zone_name, query, choosing_seconds))
+
+    def get_recent_queries_language_codes(self, limit: int):
+        return list(self.select_field(
+            field="language_code",
+            table="query",
+            group_by="language_code",
+            order_by="cast(timestamp as integer) desc",
+            limit=limit
+        ))

--- a/clock/storage/data_source/data_sources/sqlite/component/components/query.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/components/query.py
@@ -1,11 +1,13 @@
 from clock.storage.data_source.data_sources.sqlite.component.component import SqliteStorageComponent
+from clock.storage.data_source.data_sources.sqlite.component.components.user import UserSqliteComponent
 
 
 class QuerySqliteComponent(SqliteStorageComponent):
     version = 1
 
-    def __init__(self):
+    def __init__(self, user: UserSqliteComponent):
         super().__init__("query", self.version)
+        self.user = user
 
     def create(self):
         self._sql("create table if not exists query ("

--- a/clock/storage/data_source/data_sources/sqlite/component/factory.py
+++ b/clock/storage/data_source/data_sources/sqlite/component/factory.py
@@ -23,8 +23,8 @@ class SqliteStorageComponentFactory:
     def user(self):
         return self._initialized(UserSqliteComponent())
 
-    def query(self):
-        return self._initialized(QuerySqliteComponent())
+    def query(self, user: UserSqliteComponent):
+        return self._initialized(QuerySqliteComponent(user))
 
     def chat(self):
         return self._initialized(ChatSqliteComponent())

--- a/clock/storage/data_source/data_sources/sqlite/sqlite.py
+++ b/clock/storage/data_source/data_sources/sqlite/sqlite.py
@@ -76,6 +76,9 @@ class SqliteStorageDataSource(StorageDataSource):
     def set_inactive_chat(self, *args):
         return self.active_chat.set_inactive(*args)
 
+    def get_recent_queries_language_codes(self, *args):
+        return self.query.get_recent_queries_language_codes(*args)
+
     def context_manager(self):
         return self
 

--- a/clock/storage/data_source/data_sources/sqlite/sqlite.py
+++ b/clock/storage/data_source/data_sources/sqlite/sqlite.py
@@ -45,7 +45,7 @@ class SqliteStorageDataSource(StorageDataSource):
         components = SqliteStorageComponentFactory(self.connection)
         self.user = components.user()
         self.chat = components.chat()
-        self.query = components.query()
+        self.query = components.query(self.user)
         self.message = components.message()
         self.active_chat = components.active_chat()
 


### PR DESCRIPTION
- update `LocaleCache` to get X (settable by config, default is 10) most recently used language_codes from storage and cache them
- create `recent_locales_limit` config value
- add `get_recent_queries_language_codes` to storage api , to data source interface and implement it in query component
- add `get_user_language_code_at` to user component
- add `language_code` to query storage, to know it without having to search in user component
- upgrade query storage filling all previous queries language_code by searching for it in user component
- make query component depend on user component (for the upgrade)

related:
- create select, select_field and select_field_one helper methods on base component
- move add_columns to base component from message one

other:
- cache inline queries for 1 second on telegram servers (same queries on the same second will return same results)
- improve storage operation work name